### PR TITLE
Replace deprecated `name` attribute on dynamic_tag

### DIFF
--- a/lib/phexel.ex
+++ b/lib/phexel.ex
@@ -17,7 +17,7 @@ defmodule Phexel do
       )
 
     ~H"""
-    <.dynamic_tag name={@tag} {@rest}>
+    <.dynamic_tag tag_name={@tag} {@rest}>
       <%= render_slot(@inner_block) %>
     </.dynamic_tag>
     """


### PR DESCRIPTION
https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#dynamic_tag/1-attributes